### PR TITLE
fix: `room` route param validation

### DIFF
--- a/frontend/src/components/shared/sidebar/index.tsx
+++ b/frontend/src/components/shared/sidebar/index.tsx
@@ -26,7 +26,6 @@ async function getOnlineUsers() {
 		credentials: "include"
 	});
 	const data = (await res.json()) as OnlineUser[];
-	console.log(data);
 	return data;
 }
 


### PR DESCRIPTION
Only allows existing `ChatRoom`(s)

Closes #449 
Related to
 - #445 