### PR TITLE
refactor: add default value for chatroom name

### DIFF
--- a/backend/django_core/apps/chat/models.py
+++ b/backend/django_core/apps/chat/models.py
@@ -1,18 +1,25 @@
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 
 from apps.user.models import CustomUser
 from mixins.models.uuid import UUIDMixin
 
 class ChatRoom(UUIDMixin):
     class ChatRoomType(models.TextChoices):
-        DM = "DM", "DM"
+        DM = "DM", _("DM")
 
     type = models.CharField(max_length=10, choices=ChatRoomType, default=ChatRoomType.DM)
     member = models.ManyToManyField(CustomUser)
     name = models.CharField(max_length=50, null=True, blank=True)
 
+    def save(self, *args, **kwargs):
+        # assign a default name if empty
+        if not self.name:
+            self.name = "DM"
+        super().save(*args, **kwargs)
+
     def __str__(self):
-        return f"{self.id}: {self.name if self.name else self.type}"
+        return f"{self.id}: {self.name}"
 
 
 class ChatMessage(models.Model):

--- a/backend/django_core/apps/user/signals.py
+++ b/backend/django_core/apps/user/signals.py
@@ -1,9 +1,9 @@
 from django.db.models.signals import post_save
-from .models import CustomUser
 from django.dispatch import receiver
 import uuid
 from django.db import IntegrityError
 
+from .models import CustomUser
 
 @receiver(post_save, sender=CustomUser)
 def create_username(sender, instance, created, **kwargs):


### PR DESCRIPTION
Override `save` method of `ChatRoom` modal.
Closes #455 